### PR TITLE
Default to github.token

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This action comments a gif of Rick Astley when someone opens a new issue.
 
 ### `GITHUB_TOKEN`
 
-**Optional** Github token of the repository. (Defaults to `${{ github.token }}` )
+**Optional** Github token of the repository. (Defaults to `${{ github.token }}`)
 
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This action comments a gif of Rick Astley when someone opens a new issue.
 
 ### `GITHUB_TOKEN`
 
-**Optional* Github token of the repository. (Defaults to `${{ github.token }}` )
+**Optional** Github token of the repository. (Defaults to `${{ github.token }}` )
 
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This action comments a gif of Rick Astley when someone opens a new issue.
 
 ### `GITHUB_TOKEN`
 
-**Required** Github token of the repository.
+**Optional* Github token of the repository. (Defaults to `${{ github.token }}` )
 
 
 
@@ -37,5 +37,4 @@ jobs:
         uses: TejasvOnly/random-rickroll@v1.0
         with:
           percentage: 100
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
 ```

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   GITHUB_TOKEN:
     description: 'Github token of the repository'
     required: false
-    default: "${{ github.token }}
+    default: '${{ github.token }}'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,8 @@ inputs:
     default: ''
   GITHUB_TOKEN:
     description: 'Github token of the repository'
-    required: true
+    required: false
+    default: "${{ github.token }}
 runs:
   using: 'node12'
   main: 'index.js'


### PR DESCRIPTION
To simplify the action, we can pass default the `github.token` in default field for `GITHUB_TOKEN` input. This would make the action a bit less verbose for normal use. Now the action will default to Github token without needing an explicit definition. Please test it out to make sure it is working as like before.